### PR TITLE
Reworking to allow offline (serverless) searches

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # WP Static Search
 
-This plugin adds a static search engine to your Wordpress site. Static in this context means that it works in the browser without using of server-side queries, so it’s ideal for static [websites generated from a Wordpress site](https://github.com/gergelyszerovay/wp-static-proxy).
+This plugin adds a static search engine to your Wordpress site. Static in this context means that it works in the browser without using of server-side queries, so it’s ideal for static [websites generated from a Wordpress site](https://github.com/gergelyszerovay/wp-static-proxy) and can also be used offline.
 
 Since both the search and the indexing happens in the browser, this plugin is not a good fit for sites that contain hundreds of pages and posts.
 
@@ -8,11 +8,11 @@ Since both the search and the indexing happens in the browser, this plugin is no
 
 After you are installed the plugin, choose the ”Static Search” option from the left sidebar of the Wordpress admin interface. Press the ”Update Index” button and wait until the indexing is finished. Each time you change the content of the website, you should update the search index manually. 
 
-To insert the search box and the search results into the site, use the [static_search] shortcode. It’s a good practice to create a page called ”Search” with the slug ”/search/” and insert the [static_search] shortcode into this page. To redirect the search widgets to this page, append the following code to the bottom of your .htaccess file:
+To insert the search box and the search results into the site, use the [static_search] shortcode. It’s a good practice to create a page called ”Search” with the slug ”/search/” and insert the [static_search] shortcode into this page. Redirection of the search widgets to this page is provided by the plugin using JavaScript, but for server deployments performance is improved by appending the following code to the bottom of your .htaccess file:
 
 `RewriteCond %{QUERY_STRING} \\?s=([^&]+) [NC]`
 
-`RewriteRule ^$ /search/?q=%1 [NC,R,END]`
+`RewriteRule ^(index\.html)?$ /search/?q=%1 [NC,R,END]`
 
 
 This code redirects the search queries to the /search/ page, then the [static_search] shortcode processes them and shows the search results.

--- a/README.md
+++ b/README.md
@@ -14,8 +14,21 @@ To insert the search box and the search results into the site, use the [static_s
 
 `RewriteRule ^(index\.html)?$ /search/?q=%1 [NC,R,END]`
 
-
 This code redirects the search queries to the /search/ page, then the [static_search] shortcode processes them and shows the search results.
+
+## Files to include for static site generation
+
+When creating the static site, please make sure that files in the following directories are included (full paths may be needed):
+
+`/wp-content/lunr-index/`
+`/wp-content/plugins/wp-static-search/3rdparty-css-js/`
+`/wp-content/plugins/wp-static-search/css/`
+`/wp-content/plugins/wp-static-search/js/`
+
+In particular, the search index file, which might not be picked up by crawlers:
+
+`/wp-content/lunr-index/lunr-index.js`
+
 
 ## Built With
 

--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.0] - 2020-11-18
+
+### Added
+- Minor (or quite major) new release introduces support for offline, serverless searching
+- JavaScript redirect to search page 
+
+### Changed 
+- Index stored as .js file; data read directly
+- Replaced all absolute links with relative links
+
+### Removed
+- Worker functions (worker.js)
+
 ## [1.0.0] - 2020-05-08
 ### Added
 - Initial release

--- a/js/admin.js
+++ b/js/admin.js
@@ -156,7 +156,7 @@ function lunrIndex(updateIndexData) {
     });
 
     var data = {'index': idx, 'documents': updateIndexData.documents};
-    storeIndex(JSON.stringify(data));
+    storeIndex('var data = '+JSON.stringify(data)+';');
 
     document.getElementById("button_ss_update_index").disabled = false;
 

--- a/js/worker.js
+++ b/js/worker.js
@@ -1,7 +1,9 @@
 // based on mkdocs: https://github.com/mkdocs/mkdocs/blob/afa18ae2c0f2bbfc8c8a021c4e9042526fa783f3/mkdocs/contrib/search/templates/search/worker.js , 2505a90
 // mkdocs has 2 clause BSD License, Copyright © 2014, Tom Christie. All rights reserved.
 // Modificaions made by Gergely Szerovay, licensed under the Apache 2 or GPL 2+ license
+// File contents commented out by Paul Trafford following changes to search.js
 
+/*
 var base_path = 'function' === typeof importScripts ? '.' : '../../lunr-index/';
 var allowSearch = false;
 var index;
@@ -148,3 +150,4 @@ if ('function' === typeof importScripts) {
         }
     };
 }
+*/

--- a/readme.txt
+++ b/readme.txt
@@ -9,7 +9,7 @@ Stable tag: 1.0
 License: GPLv2 or later, Apache 2
 License URI: http://www.gnu.org/licenses/gpl-2.0.html, https://www.apache.org/licenses/LICENSE-2.0
 
-This plugin adds a static search engine to your Wordpress site. Static in this context means that it works in the browser without using of server-side queries, so it’s ideal for static websites generated from a Wordpress site.
+This plugin adds a static search engine to your Wordpress site. Static in this context means that it works in the browser without using of server-side queries, so it’s ideal for static websites generated from a Wordpress site and can also be used offline.
 
 == Description ==
 
@@ -23,11 +23,11 @@ Since both the search and the indexing happens in the browser, this plugin is no
 
 After you are installed the plugin, choose the ”Static Search” option from the left sidebar of the Wordpress admin interface. Press the ”Update Index” button and wait until the indexing is finished. Each time you change the content of the website, you should update the search index manually.
 
-To insert the search box and the search results into the site, use the [static_search] shortcode. It’s a good practice to create a page called ”Search” with the slug ”/search/” and insert the [static_search] shortcode into this page. To redirect the search widgets to this page, append the following code to the bottom of your .htaccess file:
+To insert the search box and the search results into the site, use the [static_search] shortcode. It’s a good practice to create a page called ”Search” with the slug ”/search/” and insert the [static_search] shortcode into this page. Redirection of the search widgets to this page is provided by the plugin using JavaScript, but for server deployments performance is improved by appending the following code to the bottom of your .htaccess file:
 
 `RewriteCond %{QUERY_STRING} \\?s=([^&]+) [NC]`
 
-`RewriteRule ^$ /search/?q=%1 [NC,R,END]`
+`RewriteRule ^(index\.html)?$ /search/?q=%1 [NC,R,END]`
 
 This code redirects the search queries to the /search/ page, then the [static_search] shortcode processes them and shows the search results.
 

--- a/readme.txt
+++ b/readme.txt
@@ -31,6 +31,19 @@ To insert the search box and the search results into the site, use the [static_s
 
 This code redirects the search queries to the /search/ page, then the [static_search] shortcode processes them and shows the search results.
 
+## Files to include for static site generation
+
+When creating the static site, please make sure that files in the following directories are included (full paths may be needed):
+
+`/wp-content/lunr-index/`
+`/wp-content/plugins/wp-static-search/3rdparty-css-js/`
+`/wp-content/plugins/wp-static-search/css/`
+`/wp-content/plugins/wp-static-search/js/`
+
+In particular, the search index file, which might not be picked up by crawlers:
+
+`/wp-content/lunr-index/lunr-index.js`
+
 ## Built With
 
 [lunar.js](https://lunrjs.com/) - Javascript search engine


### PR DESCRIPTION
Various modifications to enable the plugin to work without a server (e.g. on a memory stick).  This has required some quite radical changes in that they drop web worker methods.  

From the user side there is little difference - mainly that when using offline JavaScript handles the redirects (so they briefly see the home page loading before being redirected to the search page.

The code has been successfully tested on a couple of WordPress installations in conjunction with wget for static site generation.